### PR TITLE
Fix ending double quote scope

### DIFF
--- a/Syntaxes/SQL.plist
+++ b/Syntaxes/SQL.plist
@@ -674,7 +674,7 @@
 							<key>name</key>
 							<string>punctuation.definition.string.begin.sql</string>
 						</dict>
-						<key>3</key>
+						<key>2</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.string.end.sql</string>


### PR DESCRIPTION
The ending quote in a string.quoted.double.sql was not being highlighted correctly. This commit corrects the submatch to fix this problem.
